### PR TITLE
NO EGL init in GPU mode.One-time init,single context/surface in SW mode

### DIFF
--- a/egl.gypi
+++ b/egl.gypi
@@ -40,6 +40,8 @@
         'egl_wrapper.h',
         'egl_window.cc',
         'egl_window.h',
+        'egl_ozone_canvas.h',
+        'egl_ozone_canvas.cc'
       ],
       'link_settings': {
             'libraries': [

--- a/egl_ozone_canvas.cc
+++ b/egl_ozone_canvas.cc
@@ -1,0 +1,46 @@
+#include "egl_ozone_canvas.h"
+#include "egl_wrapper.h"
+
+namespace ui {
+#ifndef GL_BGRA_EXT
+#define GL_BGRA_EXT 0x80E1
+#endif
+
+EglOzoneCanvas::EglOzoneCanvas() : eglWrapper_(EglWrapper::getInstance()) {
+}
+
+EglOzoneCanvas::~EglOzoneCanvas() {
+  eglWrapper_.ozone_egl_textureShutDown(&userDate_);
+}
+
+void EglOzoneCanvas::ResizeCanvas(const gfx::Size& viewport_size) {
+  if (userDate_.width == viewport_size.width() &&
+      userDate_.height == viewport_size.height()) {
+    return;
+  } else if (userDate_.width != 0 && userDate_.height != 0) {
+    eglWrapper_.ozone_egl_textureShutDown(&userDate_);
+  }
+  surface_ = SkSurface::MakeRasterN32Premul(viewport_size.width(),
+                                            viewport_size.height());
+  userDate_.width = viewport_size.width();
+  userDate_.height = viewport_size.height();
+  userDate_.colorType = GL_BGRA_EXT;
+  eglWrapper_.ozone_egl_textureInit(&userDate_);
+}
+
+void EglOzoneCanvas::PresentCanvas(const gfx::Rect& damage) {
+  SkImageInfo info;
+  size_t row_bytes;
+  userDate_.data = (char*)surface_->peekPixels(&info, &row_bytes);
+  eglWrapper_.ozone_egl_textureDraw(&userDate_);
+  eglWrapper_.ozone_egl_swap();
+}
+
+scoped_ptr<gfx::VSyncProvider> EglOzoneCanvas::CreateVSyncProvider() {
+  return scoped_ptr<gfx::VSyncProvider>();
+}
+
+sk_sp<SkSurface> EglOzoneCanvas::GetSurface() {
+  return surface_;
+}
+}

--- a/egl_ozone_canvas.cc
+++ b/egl_ozone_canvas.cc
@@ -10,29 +10,29 @@ EglOzoneCanvas::EglOzoneCanvas() : eglWrapper_(EglWrapper::getInstance()) {
 }
 
 EglOzoneCanvas::~EglOzoneCanvas() {
-  eglWrapper_.ozone_egl_textureShutDown(&userDate_);
+  eglWrapper_.ozone_egl_textureShutDown(userData_);
 }
 
 void EglOzoneCanvas::ResizeCanvas(const gfx::Size& viewport_size) {
-  if (userDate_.width == viewport_size.width() &&
-      userDate_.height == viewport_size.height()) {
+  if (userData_.width == viewport_size.width() &&
+      userData_.height == viewport_size.height()) {
     return;
-  } else if (userDate_.width != 0 && userDate_.height != 0) {
-    eglWrapper_.ozone_egl_textureShutDown(&userDate_);
+  } else if (userData_.width != 0 && userData_.height != 0) {
+    eglWrapper_.ozone_egl_textureShutDown(userData_);
   }
   surface_ = SkSurface::MakeRasterN32Premul(viewport_size.width(),
                                             viewport_size.height());
-  userDate_.width = viewport_size.width();
-  userDate_.height = viewport_size.height();
-  userDate_.colorType = GL_BGRA_EXT;
-  eglWrapper_.ozone_egl_textureInit(&userDate_);
+  userData_.width = viewport_size.width();
+  userData_.height = viewport_size.height();
+  userData_.colorType = GL_BGRA_EXT;
+  eglWrapper_.ozone_egl_textureInit(userData_);
 }
 
 void EglOzoneCanvas::PresentCanvas(const gfx::Rect& damage) {
   SkImageInfo info;
   size_t row_bytes;
-  userDate_.data = (char*)surface_->peekPixels(&info, &row_bytes);
-  eglWrapper_.ozone_egl_textureDraw(&userDate_);
+  userData_.data = (char*)surface_->peekPixels(&info, &row_bytes);
+  eglWrapper_.ozone_egl_textureDraw(userData_);
   eglWrapper_.ozone_egl_swap();
 }
 

--- a/egl_ozone_canvas.h
+++ b/egl_ozone_canvas.h
@@ -33,7 +33,7 @@ class EglOzoneCanvas : public ui::SurfaceOzoneCanvas {
 
  private:
   sk_sp<SkSurface> surface_;
-  ozone_egl_UserData userDate_;
+  EglUserData userData_;
   EglWrapper& eglWrapper_;
 };
 }

--- a/egl_ozone_canvas.h
+++ b/egl_ozone_canvas.h
@@ -1,0 +1,41 @@
+#ifndef UI_EGL_OZONE_CANVAS_H_
+#define UI_EGL_OZONE_CANVAS_H_
+
+#include "base/memory/scoped_ptr.h"
+#include "ui/ozone/public/surface_ozone_egl.h"
+#include "ui/ozone/public/surface_factory_ozone.h"
+#include "ui/ozone/public/surface_ozone_canvas.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "ui/gfx/skia_util.h"
+#include "ui/gfx/vsync_provider.h"
+#include "ui/gfx/vsync_provider.h"
+#include "ui/ozone/common/egl_util.h"
+
+#include "egl_window.h"
+
+namespace ui {
+class EglWrapper;
+
+// EglOzoneCanvas is used only in the context of "sofware drawing mode".
+// It relies on EglWrapper to interact with the EGL layer.
+class EglOzoneCanvas : public ui::SurfaceOzoneCanvas {
+ public:
+  EglOzoneCanvas();
+  ~EglOzoneCanvas() override;
+  // SurfaceOzoneCanvas overrides:
+  void ResizeCanvas(const gfx::Size& viewport_size) override;
+  void PresentCanvas(const gfx::Rect& damage) override;
+
+  scoped_ptr<gfx::VSyncProvider> CreateVSyncProvider() override;
+  sk_sp<SkSurface> GetSurface() override;
+
+ private:
+  sk_sp<SkSurface> surface_;
+  ozone_egl_UserData userDate_;
+  EglWrapper& eglWrapper_;
+};
+}
+
+#endif // UI_EGL_OZONE_CANVAS_H_

--- a/egl_surface_factory.h
+++ b/egl_surface_factory.h
@@ -8,36 +8,63 @@
 #include "base/memory/scoped_ptr.h"
 #include "ui/ozone/public/surface_factory_ozone.h"
 #include "egl_window.h"
-
+#include "egl_wrapper.h"
 
 namespace gfx {
 class SurfaceOzone;
 }
 
 namespace ui {
-
+// SurfaceFactoryEgl implements SurfaceFactoryOzone providing support for
+// GPU accelerated drawing and software drawing.
+// As described in the comment of the base class, specific functions are used
+// depending on the selected path:
+//
+// 1) "accelerated" drawing:
+// - functions specific to this mode:
+//  -GetNativeDisplay, LoadEGLGLES2Bindings and CreateEGLSurfaceForWidget
+// -  support only for  the creation of a native window and  of  a SurfaceOzoneEGL  from
+// the GPU  process.
+// It's up to the caller to initialize EGL  properly and to create a context,
+// a surface and to bind the context to the  surface.
+//
+// 2) "software" drawing:
+// - function specific to this mode:
+//  - CreateCanvasForWidget
+// - support for the creation of SurfaceOzoneCanvas from the browser process.
+// (including  EGL initialization, and the binding of a new  context to a new surface created
+// in the scope of CreateCanvasForWidget()).
 class SurfaceFactoryEgl : public ui::SurfaceFactoryOzone {
  public:
   SurfaceFactoryEgl();
   ~SurfaceFactoryEgl() override  ;
 
-  // Create the window.
-  bool CreateSingleWindow();
-  void DestroySingleWindow();
-
-  // SurfaceFactoryOzone:
+  // method to be called in  accelerated drawing mode
   intptr_t GetNativeDisplay() override;
   scoped_ptr<ui::SurfaceOzoneEGL> CreateEGLSurfaceForWidget(
-      gfx::AcceleratedWidget widget) override;
+          gfx::AcceleratedWidget widget) override;
+  // method to be called in  accelerated drawing mode
   bool LoadEGLGLES2Bindings(
-      AddGLLibraryCallback add_gl_library,
-      SetGLGetProcAddressProcCallback set_gl_get_proc_address) override;
-  scoped_ptr<ui::SurfaceOzoneCanvas> CreateCanvasForWidget(
-      gfx::AcceleratedWidget widget) override;
+          AddGLLibraryCallback add_gl_library,
+          SetGLGetProcAddressProcCallback set_gl_get_proc_address) override;
+  // method to be called in  accelerated drawing mode
   intptr_t GetNativeWindow();
 
+  // method to be called in software drawing mode
+  scoped_ptr<ui::SurfaceOzoneCanvas> CreateCanvasForWidget(
+          gfx::AcceleratedWidget widget) override;
+
+
  private:
-    bool init_;
+    // needed only in accelerated drawing mode
+    bool CreateNativeWindow();
+
+
+    // needed only in accelerated drawing mode
+    NativeDisplayType native_display_;
+    // needed only in accelerated drawing mode
+    NativeWindowType native_window_;
+
 };
 
 }  // namespace ui

--- a/egl_window.cc
+++ b/egl_window.cc
@@ -17,13 +17,12 @@ namespace ui {
          EventFactoryEvdev* event_factory,
          const gfx::Rect& bounds)
      : delegate_(delegate),
-       event_factory_(event_factory),
-       bounds_(bounds),
-       surface_factory_(surface_factory) {
-   surface_factory_->CreateSingleWindow();
-   window_id_=surface_factory_->GetNativeWindow();
+     event_factory_(event_factory),
+     bounds_(bounds),
+     surface_factory_(surface_factory),
+     window_id_(surface_factory_->GetNativeWindow()){
  }
- 
+
  eglWindow::~eglWindow() {
    ui::PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
  }
@@ -36,55 +35,55 @@ namespace ui {
    PlatformEventSource::GetInstance()->AddPlatformEventDispatcher(this);
    delegate_->OnAcceleratedWidgetAvailable(window_id_, 1.f);
  }
- 
+
  gfx::Rect eglWindow::GetBounds() {
    return bounds_;
  }
- 
+
  void eglWindow::SetBounds(const gfx::Rect& bounds) {
    bounds_ = bounds;
    delegate_->OnBoundsChanged(bounds);
  }
- 
+
  void eglWindow::Show() {
  }
- 
+
  void eglWindow::Hide() {
  }
- 
+
  void eglWindow::Close() {
  }
- 
+
  void eglWindow::SetCapture() {
  }
- 
+
  void eglWindow::ReleaseCapture() {
  }
- 
+
  void eglWindow::ToggleFullscreen() {
  }
- 
+
  void eglWindow::Maximize() {
  }
- 
+
  void eglWindow::Minimize() {
  }
- 
+
  void eglWindow::Restore() {
  }
- 
+
  void eglWindow::SetCursor(PlatformCursor cursor) {
  }
- 
+
  void eglWindow::MoveCursorTo(const gfx::Point& location) {
    gfx::PointF locationF;
    locationF.SetPoint(location.x(),location.y());
    event_factory_->WarpCursorTo(window_id_, locationF);
  }
- 
+
  void eglWindow::ConfineCursorToBounds(const gfx::Rect& bounds) {
  }
- 
+
 bool eglWindow::CanDispatchEvent(const PlatformEvent& ne) {
   return true;
 }
@@ -98,5 +97,5 @@ uint32_t eglWindow::DispatchEvent(const PlatformEvent& native_event) {
 
   return POST_DISPATCH_STOP_PROPAGATION;
 }
- 
+
 }

--- a/egl_wrapper.cc
+++ b/egl_wrapper.cc
@@ -304,7 +304,7 @@ void EglWrapper::ozone_egl_textureInit (EglUserData& userData )
   glClearColor ( 0.0f, 0.0f, 0.0f, 0.0f );
 }
 
-void EglWrapper::ozone_egl_textureDraw (EglUserData& userData)
+void EglWrapper::ozone_egl_textureDraw (const EglUserData& userData)
 {
 
   GLfloat vVertices[] = { -0.96f,  0.96f, 0.0f,  // Position 0

--- a/egl_wrapper.cc
+++ b/egl_wrapper.cc
@@ -15,483 +15,356 @@
 #include "egl_wrapper.h"
 #include "base/logging.h"
 
-#if defined(EGL_API_BRCM)
-#include "bcm_host.h"
-#endif
-
-typedef NativeDisplayType NativeDisplay;
-typedef intptr_t            NativeWindow;
-typedef void *            NativePixmap;
-
-typedef struct fbdev_window
-{
-    unsigned short width;
-    unsigned short height;
-} fbdev_window;
-
-
-//rgba8888
-/*
-static EGLint g_configAttribs[] = {
-    EGL_RED_SIZE, 8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE, 8,
-    EGL_ALPHA_SIZE, 8,
-    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-    EGL_NONE,
-};
-  */
-static EGLint g_configAttribs[] = {
-    EGL_RED_SIZE, 5,
-    EGL_GREEN_SIZE, 6,
-    EGL_BLUE_SIZE, 5,
-    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-    EGL_NONE,
-};
-
-static EGLDisplay g_EglDisplay = NULL;
-static EGLContext g_EglContext = NULL;
-static EGLSurface g_EglSurface = NULL;
-
-static NativeDisplayType g_NativeDisplay= NULL;
-static NativeWindowType g_NativeWindow;
-
-static int g_WindowWidth=0;
-static int g_WindowHeight=0;
-
-
-NativeDisplay ozone_egl_nativeCreateDisplay(void)
-{
-#if defined(EGL_API_FB)
-    return (NativeDisplay)fbGetDisplayByIndex(0);
-#else
-    return EGL_DEFAULT_DISPLAY;
-#endif
-}
-
-void ozone_egl_nativeDestroyDisplay(NativeDisplay display)
-{
-    return;
-}
-
-NativeWindowType ozone_egl_GetNativeWin(){
-  return g_NativeWindow;
-}
-
-NativeWindow ozone_egl_nativeCreateWindow(const char *title, int width, int height, EGLint visualId)
-{
-    fbdev_window *fbwin =(fbdev_window *) malloc( sizeof(fbdev_window));
-    if (NULL == fbwin)
-    {
-        return 0;
-    }
-
-    fbwin->width  = width;
-    fbwin->height = height;
-    return (NativeWindow) fbwin;
-}
-
-void ozone_egl_nativeDestroyWindow(NativeWindow window)
-{
-    if(window !=0 )
-    {
-       free((fbdev_window*) window);
-    }
-}
-
-EGLint ozone_egl_setup(EGLint x, EGLint y, EGLint width, EGLint height )
-{
-    EGLConfig configs[10];
-    EGLint matchingConfigs;
-    EGLint err;
-
-#if defined(EGL_API_BRCM)
-    bcm_host_init();
-#endif
-
-    EGLint ctxAttribs[] =
-    {
-        EGL_CONTEXT_CLIENT_VERSION, 2,
-        EGL_NONE
-    };
-
-    eglBindAPI(EGL_OPENGL_ES_API);
-
-    g_NativeDisplay = (NativeDisplayType)ozone_egl_nativeCreateDisplay();
-#if defined(EGL_API_FB)
-    fbGetDisplayGeometry(g_NativeDisplay,&g_WindowWidth,&g_WindowHeight);
-#elif defined(EGL_API_BRCM)
-    uint32_t w = 1280;
-	uint32_t h = 720;
-    if (graphics_get_display_size(0, &w, &h) >= 0) {
-        g_WindowWidth = w;
-        g_WindowHeight = h;
-        LOG(INFO) << "Detected display size: " << w << "x" << h;
-    } else
-        LOG(ERROR) << "Failed to detect display size, using default: " << w << "x" << h;
-#endif
-
-    g_EglDisplay = eglGetDisplay(g_NativeDisplay);
-    if (g_EglDisplay == EGL_NO_DISPLAY)
-    {
-        LOG(ERROR) << "eglGetDisplay returned EGL_NO_DISPLAY";
-        return OZONE_EGL_FAILURE;
-    }
-
-    EGLint major, minor;
-    if (!eglInitialize(g_EglDisplay, &major, &minor))
-    {
-    	LOG(ERROR) << "eglInitialize failed.";
-        return OZONE_EGL_FAILURE;
-    }
-    LOG(INFO) << "EGL impl. version: " << major << "." << minor;
-
-    if (!eglChooseConfig(g_EglDisplay, g_configAttribs, &configs[0],
-                         sizeof(configs)/sizeof(configs[0]), &matchingConfigs))
-    {
-    	LOG(ERROR) << "eglChooseConfig failed.";
-        return OZONE_EGL_FAILURE;
-    }
-
-    if (matchingConfigs < 1)
-    {
-    	LOG(ERROR) << "No matching configs found";
-        return OZONE_EGL_FAILURE;
-    }
-
-    g_EglContext = eglCreateContext(g_EglDisplay, configs[0], NULL, ctxAttribs);
-    if (g_EglContext == EGL_NO_CONTEXT)
-    {
-    	LOG(ERROR) << "Failed to get EGL Context";
-        return OZONE_EGL_FAILURE;
-    }
-
-#if defined(EGL_API_FB)
-    g_NativeWindow = fbCreateWindow(g_NativeDisplay, 0, 0, g_WindowWidth, g_WindowHeight);
-#elif defined(EGL_API_BRCM)
-    static EGL_DISPMANX_WINDOW_T dispManWindow;
-    DISPMANX_ELEMENT_HANDLE_T dispmanElement;
-    DISPMANX_DISPLAY_HANDLE_T dispmanDisplay;
-    DISPMANX_UPDATE_HANDLE_T dispmanUpdate;
-    VC_RECT_T dst_rect;
-    VC_RECT_T src_rect;
-
-    dst_rect.x = 0;
-    dst_rect.y = 0;
-    dst_rect.width = g_WindowWidth;
-    dst_rect.height = g_WindowHeight;
-
-    src_rect.x = 0;
-    src_rect.y = 0;
-    src_rect.width = g_WindowWidth << 16;
-    src_rect.height = g_WindowHeight << 16;
-
-    dispmanDisplay = vc_dispmanx_display_open(0);
-    dispmanUpdate = vc_dispmanx_update_start(0);
-
-    dispmanElement = vc_dispmanx_element_add(dispmanUpdate, dispmanDisplay, 0, &dst_rect, 0, &src_rect, DISPMANX_PROTECTION_NONE, 0, 0, DISPMANX_NO_ROTATE);
-
-    dispManWindow.element = dispmanElement;
-    dispManWindow.width = g_WindowWidth;
-    dispManWindow.height = g_WindowHeight;
-    vc_dispmanx_update_submit_sync(dispmanUpdate);
-
-    g_NativeWindow = static_cast<NativeWindowType>(&dispManWindow);
-#endif
-
-    g_EglSurface = eglCreateWindowSurface(g_EglDisplay, configs[0], g_NativeWindow, NULL);
-    if (g_EglSurface == NULL)
-    {
-        LOG(ERROR) << "g_EglSurface == EGL_NO_SURFACE eglGeterror = " << eglGetError();
-        return OZONE_EGL_FAILURE;
-    }
-
-    eglMakeCurrent(g_EglDisplay, g_EglSurface, g_EglSurface, g_EglContext);
-    if (EGL_SUCCESS != (err = eglGetError()))
-    {
-        LOG(ERROR) << "Failed eglMakeCurrent. eglGetError = 0x%x\n" << err;
-        return OZONE_EGL_FAILURE;
-    }
-
-    return OZONE_EGL_SUCCESS;
-}
-
-int ozone_egl_destroy()
-{
-
-    int s32Loop = 0;
-
-    /** clean double buffer  **/
-    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-
-    for (s32Loop = 0; s32Loop < 2; s32Loop++)
-    {
-        glClear(GL_COLOR_BUFFER_BIT);
-        ozone_egl_swap();
-    }
-
-    eglMakeCurrent(g_EglDisplay, NULL, NULL, NULL);
-
-    if (g_EglContext)
-    {
-        eglDestroyContext(g_EglDisplay, g_EglContext);
-    }
-
-    if (g_EglSurface)
-    {
-        eglDestroySurface(g_EglDisplay, g_EglSurface);
-    }
-
-    eglTerminate(g_EglDisplay);
-
-    //ozone_egl_nativeDestroyWindow(g_NativeWindow);
-    ozone_egl_nativeDestroyDisplay(g_NativeDisplay);
-
-    return OZONE_EGL_SUCCESS;
-}
-
-int ozone_egl_swap()
-{
-    eglSwapBuffers(g_EglDisplay, g_EglSurface);
-
-    return OZONE_EGL_SUCCESS;
-}
-
-NativeDisplayType ozone_egl_getNativedisp()
-{
-    return g_NativeDisplay;
-}
-
-EGLint * ozone_egl_getConfigAttribs()
-{
-    return g_configAttribs;
-}
-
-EGLDisplay ozone_egl_getdisp()
-{
-    return g_EglDisplay;
-}
-
-EGLSurface ozone_egl_getsurface()
-{
-    return g_EglSurface;
-}
-
-
-void ozone_egl_makecurrent()
-{
-    eglMakeCurrent(g_EglDisplay, g_EglSurface, g_EglSurface, g_EglContext);
-}
+namespace {
 
 GLuint ozone_egl_loadShader ( GLenum type, const char *shaderSrc )
 {
-   GLuint shader;
-   GLint compiled;
-   
-   // Create the shader object
-   shader = glCreateShader ( type );
+  GLuint shader;
+  GLint compiled;
 
-   if ( shader == 0 )
-   	return 0;
+  // Create the shader object
+  shader = glCreateShader ( type );
 
-   // Load the shader source
-   glShaderSource ( shader, 1, &shaderSrc, NULL );
-   
-   // Compile the shader
-   glCompileShader ( shader );
+  if ( shader == 0 )
+    return 0;
 
-   // Check the compile status
-   glGetShaderiv ( shader, GL_COMPILE_STATUS, &compiled );
+  // Load the shader source
+  glShaderSource ( shader, 1, &shaderSrc, nullptr );
 
-   if ( !compiled ) 
-   {
-      GLint infoLen = 0;
+  // Compile the shader
+  glCompileShader ( shader );
 
-      glGetShaderiv ( shader, GL_INFO_LOG_LENGTH, &infoLen );
-      
-      if ( infoLen > 1 )
-      {
-         char* infoLog = new char[infoLen];
+  // Check the compile status
+  glGetShaderiv ( shader, GL_COMPILE_STATUS, &compiled );
 
-         glGetShaderInfoLog ( shader, infoLen, NULL, infoLog );
-         printf ( "Error compiling shader:%s\n", infoLog );            
-         
-         delete[] infoLog;
-      }
+  if ( !compiled )
+  {
+    GLint infoLen = 0;
 
-      glDeleteShader ( shader );
-      return 0;
-   }
+    glGetShaderiv ( shader, GL_INFO_LOG_LENGTH, &infoLen );
 
-   return shader;
+    if ( infoLen > 1 )
+    {
+      char* infoLog = new char[infoLen];
+
+      glGetShaderInfoLog ( shader, infoLen, nullptr, infoLog );
+      printf ( "Error compiling shader:%s\n", infoLog );
+
+      delete[] infoLog;
+    }
+
+    glDeleteShader ( shader );
+    return 0;
+  }
+
+  return shader;
 
 }
+
 GLuint ozone_egl_loadProgram ( const char *vertShaderSrc, const char *fragShaderSrc )
 {
 
-   GLuint vertexShader;
-   GLuint fragmentShader;
-   GLuint programObject;
-   GLint linked;
+  GLuint vertexShader;
+  GLuint fragmentShader;
+  GLuint programObject;
+  GLint linked;
 
-   // Load the vertex/fragment shaders
-   vertexShader = ozone_egl_loadShader ( GL_VERTEX_SHADER, vertShaderSrc );
-   if ( vertexShader == 0 )
-      return 0;
+  // Load the vertex/fragment shaders
+  vertexShader = ozone_egl_loadShader ( GL_VERTEX_SHADER, vertShaderSrc );
+  if ( vertexShader == 0 )
+    return 0;
 
-   fragmentShader = ozone_egl_loadShader ( GL_FRAGMENT_SHADER, fragShaderSrc );
-   if ( fragmentShader == 0 )
-   {
-      glDeleteShader( vertexShader );
-      return 0;
-   }
+  fragmentShader = ozone_egl_loadShader ( GL_FRAGMENT_SHADER, fragShaderSrc );
+  if ( fragmentShader == 0 )
+  {
+    glDeleteShader( vertexShader );
+    return 0;
+  }
 
-   // Create the program object
-   programObject = glCreateProgram ( );
-   
-   if ( programObject == 0 )
-      return 0;
+  // Create the program object
+  programObject = glCreateProgram ( );
 
-   glAttachShader ( programObject, vertexShader );
-   glAttachShader ( programObject, fragmentShader );
+  if ( programObject == 0 )
+    return 0;
 
-   // Link the program
-   glLinkProgram ( programObject );
+  glAttachShader ( programObject, vertexShader );
+  glAttachShader ( programObject, fragmentShader );
 
-   // Check the link status
-   glGetProgramiv ( programObject, GL_LINK_STATUS, &linked );
+  // Link the program
+  glLinkProgram ( programObject );
 
-   if ( !linked ) 
-   {
-      GLint infoLen = 0;
+  // Check the link status
+  glGetProgramiv ( programObject, GL_LINK_STATUS, &linked );
 
-      glGetProgramiv ( programObject, GL_INFO_LOG_LENGTH, &infoLen );
-      
-      if ( infoLen > 1 )
-      {
-         char* infoLog = new char[infoLen];
+  if ( !linked )
+  {
+    GLint infoLen = 0;
 
-         glGetProgramInfoLog ( programObject, infoLen, NULL, infoLog );
-         printf ( "Error linking program:%s\n", infoLog );            
-         
-         delete[] infoLog;
-      }
+    glGetProgramiv ( programObject, GL_INFO_LOG_LENGTH, &infoLen );
 
-      glDeleteProgram ( programObject );
-      return 0;
-   }
+    if ( infoLen > 1 )
+    {
+      char* infoLog = new char[infoLen];
 
-   // Free up no longer needed shader resources
-   glDeleteShader ( vertexShader );
-   glDeleteShader ( fragmentShader );
+      glGetProgramInfoLog ( programObject, infoLen, nullptr, infoLog );
+      printf ( "Error linking program:%s\n", infoLog );
 
-   return programObject;
+      delete[] infoLog;
+    }
+
+    glDeleteProgram ( programObject );
+    return 0;
+  }
+
+  // Free up no longer needed shader resources
+  glDeleteShader ( vertexShader );
+  glDeleteShader ( fragmentShader );
+
+  return programObject;
 }
 
+} // end of unnamed namespace
 
+namespace ui {
 
-int ozone_egl_textureInit (ozone_egl_UserData * userData )
+EglWrapper::EglWrapper()
 {
-   GLbyte vShaderStr[] =  
-      "attribute vec4 a_position;   \n"
-      "attribute vec2 a_texCoord;   \n"
-      "varying vec2 v_texCoord;     \n"
-      "void main()                  \n"
-      "{                            \n"
-      "   gl_Position = a_position; \n"
-      "   v_texCoord = a_texCoord;  \n"
-      "}                            \n";
-   
-   GLbyte fShaderStr[] =  
-      "precision mediump float;                            \n"
-      "varying vec2 v_texCoord;                            \n"
-      "uniform sampler2D s_texture;                        \n"
-      "void main()                                         \n"
-      "{                                                   \n"
-      "  gl_FragColor = texture2D( s_texture, v_texCoord );\n"
-      "}                                                   \n";
-      
-
-   // Load the shaders and get a linked program object
-   userData->programObject = ozone_egl_loadProgram ( (const char *)vShaderStr, (const char*)fShaderStr );
-
-   // Get the attribute locations
-   userData->positionLoc = glGetAttribLocation ( userData->programObject, "a_position" );
-   userData->texCoordLoc = glGetAttribLocation ( userData->programObject, "a_texCoord" );
-   
-   // Get the sampler location
-   userData->samplerLoc = glGetUniformLocation ( userData->programObject, "s_texture" );
-   
-   // Load the texture
-   glGenTextures ( 1, &(userData->textureId) );
-   glBindTexture ( GL_TEXTURE_2D, userData->textureId );
-   
-   printf("-----glTexImage2D %d %d %d\n",userData->colorType, userData->width,userData->height);
-   glTexImage2D ( GL_TEXTURE_2D, 0, userData->colorType, userData->width, userData->height, 0, userData->colorType, GL_UNSIGNED_BYTE, NULL );
-   
-   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-   glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-
-   glClearColor ( 0.0f, 0.0f, 0.0f, 0.0f );
-   return GL_TRUE;
+  ozone_egl_setup();
 }
 
-
-void ozone_egl_textureDraw ( ozone_egl_UserData *userData)
+EglWrapper::~EglWrapper()
 {
-                         
-   GLfloat vVertices[] = { -0.96f,  0.96f, 0.0f,  // Position 0
-                            0.0f,  0.0f,        // TexCoord 0 
-                           -0.96f, -0.96f, 0.0f,  // Position 1
-                            0.0f,  1.0f,        // TexCoord 1
-                            0.96f, -0.96f, 0.0f,  // Position 2
-                            1.0f,  1.0f,        // TexCoord 2
-                            0.96f,  0.96f, 0.0f,  // Position 3
-                            1.0f,  0.0f         // TexCoord 3
-                         };                    
-                 
-   GLushort indices[] = { 0, 1, 2, 0, 2, 3 };
-   
-   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, userData->width, userData->height, userData->colorType, GL_UNSIGNED_BYTE, userData->data); 
-      
-   // Set the viewport
-   glViewport ( 0, 0, g_WindowWidth, g_WindowHeight );
-   
-   // Clear the color buffer
-   glClear ( GL_COLOR_BUFFER_BIT );
-
-   // Use the program object
-   glUseProgram ( userData->programObject );
-
-   // Load the vertex position
-   glVertexAttribPointer ( userData->positionLoc, 3, GL_FLOAT, 
-                           GL_FALSE, 5 * sizeof(GLfloat), vVertices );
-   // Load the texture coordinate
-   glVertexAttribPointer ( userData->texCoordLoc, 2, GL_FLOAT,
-                           GL_FALSE, 5 * sizeof(GLfloat), &vVertices[3] );
-
-   glEnableVertexAttribArray ( userData->positionLoc );
-   glEnableVertexAttribArray ( userData->texCoordLoc );
-
-   // Bind the texture
-   glActiveTexture ( GL_TEXTURE0 );
-   glBindTexture ( GL_TEXTURE_2D, userData->textureId );
-
-   // Set the sampler texture unit to 0
-   glUniform1i ( userData->samplerLoc, 0 );
-
-   glDrawElements ( GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, indices );
-
+  ozone_egl_destroy();
 }
 
-
-void ozone_egl_textureShutDown ( ozone_egl_UserData *userData )
+// Lazy implementation of singleton (thread-safe since C++11)
+EglWrapper& EglWrapper::getInstance()
 {
-   // Delete texture object
-   glDeleteTextures ( 1, &(userData->textureId) );
-
-   // Delete program object
-   glDeleteProgram ( userData->programObject );
+  static EglWrapper eglWrapper;
+  return eglWrapper;
 }
+
+bool EglWrapper::ozone_egl_setup()
+{
+  EGLConfig configs[10];
+  EGLint matchingConfigs;
+  EGLint err;
+
+  EGLint ctxAttribs[] =
+  {
+    EGL_CONTEXT_CLIENT_VERSION, 2,
+    EGL_NONE
+  };
+
+    eglBindAPI(EGL_OPENGL_ES_API);
+
+#if defined(EGL_API_FB)
+    nativeDisplay_ = (NativeDisplayType)fbGetDisplayByIndex(0);
+    fbGetDisplayGeometry(nativeDisplay_,&windowWidth_,&windowHeight_);
+#endif
+
+  eglDisplay_ = eglGetDisplay(nativeDisplay_);
+  if (eglDisplay_ == EGL_NO_DISPLAY)
+  {
+    LOG(ERROR) << "eglGetDisplay returned EGL_NO_DISPLAY";
+    return false;
+  }
+
+  EGLint major, minor;
+  if (!eglInitialize(eglDisplay_, &major, &minor))
+  {
+    LOG(ERROR) << "eglInitialize failed.";
+    return false;
+  }
+  LOG(INFO) << "EGL impl. version: " << major << "." << minor;
+
+  if (!eglChooseConfig(eglDisplay_, configAttribs_, &configs[0],
+        sizeof(configs)/sizeof(configs[0]), &matchingConfigs))
+  {
+    LOG(ERROR) << "eglChooseConfig failed.";
+    return false;
+  }
+
+  if (matchingConfigs < 1)
+  {
+    LOG(ERROR) << "No matching configs found";
+    return false;
+  }
+
+  eglContext_ = eglCreateContext(eglDisplay_, configs[0], nullptr, ctxAttribs);
+  if (eglContext_ == EGL_NO_CONTEXT)
+  {
+    LOG(ERROR) << "Failed to get EGL Context";
+    return false;
+  }
+
+#if defined(EGL_API_FB)
+  nativeWindow_ = fbCreateWindow(nativeDisplay_, 0, 0, windowWidth_, windowHeight_);
+#endif
+
+  eglSurface_ = eglCreateWindowSurface(eglDisplay_, configs[0], nativeWindow_, nullptr);
+  if (eglSurface_ == nullptr)
+  {
+    LOG(ERROR) << "eglSurface_ == EGL_NO_SURFACE eglGeterror = " << eglGetError();
+    return false;
+  }
+
+  eglMakeCurrent(eglDisplay_, eglSurface_, eglSurface_, eglContext_);
+  if (EGL_SUCCESS != (err = eglGetError()))
+  {
+    LOG(ERROR) << "Failed eglMakeCurrent. eglGetError = 0x%x\n" << err;
+    return false;
+  }
+
+  return true;
+}
+
+bool EglWrapper::ozone_egl_destroy()
+{
+
+  int s32Loop = 0;
+
+  /** clean double buffer  **/
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+
+  for (s32Loop = 0; s32Loop < 2; s32Loop++)
+  {
+    glClear(GL_COLOR_BUFFER_BIT);
+    ozone_egl_swap();
+  }
+
+  eglMakeCurrent(eglDisplay_, nullptr, nullptr, nullptr);
+
+  if (eglContext_)
+  {
+    eglDestroyContext(eglDisplay_, eglContext_);
+  }
+
+  if (eglSurface_)
+  {
+    eglDestroySurface(eglDisplay_, eglSurface_);
+  }
+
+  eglTerminate(eglDisplay_);
+
+  return true;
+}
+
+bool EglWrapper::ozone_egl_swap()
+{
+  eglSwapBuffers(eglDisplay_, eglSurface_);
+
+  return true;
+}
+
+void EglWrapper::ozone_egl_makecurrent()
+{
+  eglMakeCurrent(eglDisplay_, eglSurface_, eglSurface_, eglContext_);
+}
+
+int EglWrapper::ozone_egl_textureInit (ozone_egl_UserData * userData )
+{
+  GLbyte vShaderStr[] =
+    "attribute vec4 a_position;   \n"
+    "attribute vec2 a_texCoord;   \n"
+    "varying vec2 v_texCoord;     \n"
+    "void main()                  \n"
+    "{                            \n"
+    "   gl_Position = a_position; \n"
+    "   v_texCoord = a_texCoord;  \n"
+    "}                            \n";
+
+  GLbyte fShaderStr[] =
+    "precision mediump float;                            \n"
+    "varying vec2 v_texCoord;                            \n"
+    "uniform sampler2D s_texture;                        \n"
+    "void main()                                         \n"
+    "{                                                   \n"
+    "  gl_FragColor = texture2D( s_texture, v_texCoord );\n"
+    "}                                                   \n";
+
+
+  // Load the shaders and get a linked program object
+  userData->programObject = ozone_egl_loadProgram ( (const char *)vShaderStr, (const char*)fShaderStr );
+
+  // Get the attribute locations
+  userData->positionLoc = glGetAttribLocation ( userData->programObject, "a_position" );
+  userData->texCoordLoc = glGetAttribLocation ( userData->programObject, "a_texCoord" );
+
+  // Get the sampler location
+  userData->samplerLoc = glGetUniformLocation ( userData->programObject, "s_texture" );
+
+  // Load the texture
+  glGenTextures ( 1, &(userData->textureId) );
+  glBindTexture ( GL_TEXTURE_2D, userData->textureId );
+
+  printf("-----glTexImage2D %d %d %d\n",userData->colorType, userData->width,userData->height);
+  glTexImage2D ( GL_TEXTURE_2D, 0, userData->colorType, userData->width, userData->height, 0, userData->colorType, GL_UNSIGNED_BYTE, nullptr );
+
+  glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+  glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+  glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+  glTexParameteri ( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+
+  glClearColor ( 0.0f, 0.0f, 0.0f, 0.0f );
+  return GL_TRUE;
+}
+
+void EglWrapper::ozone_egl_textureDraw ( ozone_egl_UserData *userData)
+{
+
+  GLfloat vVertices[] = { -0.96f,  0.96f, 0.0f,  // Position 0
+    0.0f,  0.0f,        // TexCoord 0
+    -0.96f, -0.96f, 0.0f,  // Position 1
+    0.0f,  1.0f,        // TexCoord 1
+    0.96f, -0.96f, 0.0f,  // Position 2
+    1.0f,  1.0f,        // TexCoord 2
+    0.96f,  0.96f, 0.0f,  // Position 3
+    1.0f,  0.0f         // TexCoord 3
+  };
+
+  GLushort indices[] = { 0, 1, 2, 0, 2, 3 };
+
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, userData->width, userData->height, userData->colorType, GL_UNSIGNED_BYTE, userData->data);
+
+  // Set the viewport
+  glViewport ( 0, 0, windowWidth_, windowHeight_ );
+
+  // Clear the color buffer
+  glClear ( GL_COLOR_BUFFER_BIT );
+
+  // Use the program object
+  glUseProgram ( userData->programObject );
+
+  // Load the vertex position
+  glVertexAttribPointer ( userData->positionLoc, 3, GL_FLOAT,
+      GL_FALSE, 5 * sizeof(GLfloat), vVertices );
+  // Load the texture coordinate
+  glVertexAttribPointer ( userData->texCoordLoc, 2, GL_FLOAT,
+      GL_FALSE, 5 * sizeof(GLfloat), &vVertices[3] );
+
+  glEnableVertexAttribArray ( userData->positionLoc );
+  glEnableVertexAttribArray ( userData->texCoordLoc );
+
+  // Bind the texture
+  glActiveTexture ( GL_TEXTURE0 );
+  glBindTexture ( GL_TEXTURE_2D, userData->textureId );
+
+  // Set the sampler texture unit to 0
+  glUniform1i ( userData->samplerLoc, 0 );
+
+  glDrawElements ( GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, indices );
+
+}
+
+
+void EglWrapper::ozone_egl_textureShutDown ( ozone_egl_UserData *userData )
+{
+  // Delete texture object
+  glDeleteTextures ( 1, &(userData->textureId) );
+
+  // Delete program object
+  glDeleteProgram ( userData->programObject );
+}
+
+} // end of namespace ui

--- a/egl_wrapper.h
+++ b/egl_wrapper.h
@@ -8,66 +8,79 @@
 #include <GLES2/gl2.h>
 #include <EGL/egl.h>
 
-#define OZONE_EGL_SUCCESS 1
-#define OZONE_EGL_FAILURE 0
+namespace ui {
 
-#define GLCheckError() \
-    {                                                                \
-        GLint err = glGetError();                                    \
-        if (err != GL_NO_ERROR)                                      \
-        {                                                            \
-            fprintf(stderr, "\nfunction: %s, line: %d, err: 0x%x\n", \
-                    __FUNCTION__, __LINE__, err);                              \
-            return HI_FAILURE;                                       \
-        }                                                            \
-    }
-
-#define EGLCheckError() \
-    {                                                                \
-        GLint err = eglGetError();                                   \
-        if (err != EGL_SUCCESS)                                      \
-        {                                                            \
-            fprintf(stderr, "\nfunction: %s, line: %d, err: 0x%x\n", \
-                    __FUNCTION__, __LINE__, err);                              \
-            return HI_FAILURE;                                       \
-        }                                                            \
-    }
-
-
-typedef struct
+struct ozone_egl_UserData
 {
-   // Handle to a program object
-   GLuint programObject;
+  // Handle to a program object
+  GLuint programObject = 0;
 
-   // Attribute locations
-   GLint  positionLoc;
-   GLint  texCoordLoc;
+  // Attribute locations
+  GLint  positionLoc = 0;
+  GLint  texCoordLoc = 0;
 
-   // Sampler location
-   GLint samplerLoc;
+  // Sampler location
+  GLint samplerLoc = 0;
 
-   // Texture handle
-   GLuint textureId;
-   
-   GLint colorType;
-   GLint width;
-   GLint height;
-   char * data;
+  // Texture handle
+  GLuint textureId = 0;
 
-} ozone_egl_UserData;
+  GLint colorType = 0;
+  GLint width = 0;
+  GLint height = 0;
+  char * data = nullptr;
 
+};
 
-EGLint ozone_egl_setup(EGLint x, EGLint y, EGLint width, EGLint height );
-int     ozone_egl_destroy();
-int     ozone_egl_swap();
-NativeDisplayType ozone_egl_getNativedisp();
-EGLint * ozone_egl_getConfigAttribs();
-EGLDisplay ozone_egl_getdisp();
-EGLSurface ozone_egl_getsurface();
-void ozone_egl_makecurrent();
-int ozone_egl_textureInit (ozone_egl_UserData * userData );
-void ozone_egl_textureDraw ( ozone_egl_UserData *userData );
-void ozone_egl_textureShutDown ( ozone_egl_UserData *userData );
-NativeWindowType ozone_egl_GetNativeWin();
+// EglWrapper is meant to be used only in the context of "software drawing" mode.
+// It provides a wrapper around EGL library.
+// The singleton pattern is used to enforce a one-time EGL initialization and to avoid to
+// bind 2 (or more) different contexts in 2 different threads to 2 different surfaces
+// (not  portable, it may fail or not depending on the GPU implementation).
+// To achieve this, the initialization, the creation of a new context and a
+// new surface, and the binding are done in ctor, and the cleanup in the dtor of
+// the singleton.
+class EglWrapper {
+ public:
+  static EglWrapper& getInstance();
+
+  bool ozone_egl_swap();
+  void ozone_egl_makecurrent();
+  int ozone_egl_textureInit(ozone_egl_UserData *userData);
+  void ozone_egl_textureDraw(ozone_egl_UserData *userData);
+  void ozone_egl_textureShutDown(ozone_egl_UserData *userData);
+
+  // getter
+  NativeDisplayType ozone_egl_getNativedisp() const { return nativeDisplay_; }
+  EGLint *ozone_egl_getConfigAttribs() { return configAttribs_; }
+  EGLDisplay ozone_egl_getdisp() const { return eglDisplay_; }
+  EGLSurface ozone_egl_getsurface() const { return eglSurface_; }
+  NativeWindowType ozone_egl_GetNativeWin() const { return nativeWindow_; }
+
+ private:
+  EglWrapper();
+  ~EglWrapper();
+  EglWrapper(EglWrapper const &) = delete;
+  EglWrapper(EglWrapper &&) = delete;
+  EglWrapper &operator=(EglWrapper const &) = delete;
+  EglWrapper &operator=(EglWrapper &&) = delete;
+
+  bool ozone_egl_setup();
+  bool ozone_egl_destroy();
+
+ private:
+  EGLDisplay eglDisplay_ = nullptr;
+  EGLContext eglContext_ = nullptr;
+  EGLSurface eglSurface_ = nullptr;
+  NativeDisplayType nativeDisplay_ = EGL_DEFAULT_DISPLAY;
+  NativeWindowType nativeWindow_;
+  int windowWidth_ = 0;
+  int windowHeight_= 0;
+  EGLint configAttribs_[9] =  { EGL_RED_SIZE,  5, EGL_GREEN_SIZE, 6, EGL_BLUE_SIZE, 5,
+      EGL_SURFACE_TYPE, EGL_WINDOW_BIT, EGL_NONE };
+
+};
+
+}
 
 #endif

--- a/egl_wrapper.h
+++ b/egl_wrapper.h
@@ -10,7 +10,7 @@
 
 namespace ui {
 
-struct ozone_egl_UserData
+struct EglUserData
 {
   // Handle to a program object
   GLuint programObject = 0;
@@ -46,9 +46,9 @@ class EglWrapper {
 
   bool ozone_egl_swap();
   void ozone_egl_makecurrent();
-  int ozone_egl_textureInit(ozone_egl_UserData *userData);
-  void ozone_egl_textureDraw(ozone_egl_UserData *userData);
-  void ozone_egl_textureShutDown(ozone_egl_UserData *userData);
+  void ozone_egl_textureInit(EglUserData& userData);
+  void ozone_egl_textureDraw(EglUserData& userData);
+  void ozone_egl_textureShutDown(EglUserData& userData);
 
   // getter
   NativeDisplayType ozone_egl_getNativedisp() const { return nativeDisplay_; }

--- a/egl_wrapper.h
+++ b/egl_wrapper.h
@@ -47,7 +47,7 @@ class EglWrapper {
   bool ozone_egl_swap();
   void ozone_egl_makecurrent();
   void ozone_egl_textureInit(EglUserData& userData);
-  void ozone_egl_textureDraw(EglUserData& userData);
+  void ozone_egl_textureDraw(const EglUserData& userData);
   void ozone_egl_textureShutDown(EglUserData& userData);
 
   // getter

--- a/ozone_platform_egl.cc
+++ b/ozone_platform_egl.cc
@@ -18,7 +18,6 @@
 #include "ui/ozone/public/system_input_injector.h"
 #include "ui/platform_window/platform_window.h"
 #include "egl_window.h"
-#include "egl_wrapper.h"
 
 namespace ui {
 


### PR DESCRIPTION
 - in  GPU accelerated mode,do not perform any EGL initialization,context
 creation, and binding of a context to a new surface. This is done to avoid 
the creation of different contexts and surfaces and related binding in different 
threads (not portable, it may work or not depending on GPU implementation)
 - in software mode, introduce an EglWrapper singleton class responsible
 to initialize EGL and to create a context, a surface and to bind the
 context to the surface. 
 - remove support for Raspberry PI while setting up EGL (i.e. remove
 bcm_init() and VCHIQ ioctl in ozone_egl_setup()).
 - clean-up the code (EglCanvas in a separate compilation unit, avoid crash
in ozone_egl_texture*() methods if a null pointer is received as paramter,
remove unused code, replace printf with LOG() and minor cosmetic changes)

Notes: 

1.  to run the browser in "software-drawing" mode (i.e. with GPU 
compositing disabled)  specify the `--disable-gpu` flag.
2.  We can end up in software-drawing mode as a fallback mode in case
we start the browser in GPU-accelerated mode (default choice / `--enable-gpu`) 
and then in Aura's WindowTree initialization, 
`GpuProcessTransportFactory::EstablishedGpuChannel`  fails for 4 times in row 
(in current implementation `kNumRetriesBeforeSoftwareFallback=4`)